### PR TITLE
fix: update base image to resolve OpenSSL CVEs (CVE-2026-31789, CVE-2026-28387/88/89/90)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.26.0-alpine3.22
+FROM golang:1.26-alpine3.24
+
+RUN apk upgrade --no-cache
 
 WORKDIR /app
 COPY go.mod ./


### PR DESCRIPTION
## Snyk Remediation

Fixes 5 Critical/High OpenSSL CVEs reported in Snyk weekly report (June 18-25, 2026):

- CVE-2026-31789: Heap buffer overflow in hex conversion
- CVE-2026-28387: Use-after-free in DANE TLSA client
- CVE-2026-28388: NULL deref in delta CRL processing
- CVE-2026-28389: NULL deref in CMS KeyAgreeRecipientInfo
- CVE-2026-28390: NULL deref in CMS KeyTransportRecipientInfo

All fixed in OpenSSL >= 3.0.20.

**Changes:**
- Bumped base image from golang:1.26.0-alpine3.22 to golang:1.26-alpine3.24
- Added `apk upgrade --no-cache` to apply latest security patches at build time